### PR TITLE
WIP Make the SSL certificate optional

### DIFF
--- a/game/Scripts/Game/MasterServer.gd
+++ b/game/Scripts/Game/MasterServer.gd
@@ -127,6 +127,9 @@ func connect_to_server() -> void:
 	if custom_server.empty():
 		if custom_certificate_ok:
 			push_warning("SSL certificate provided with no custom master server, ignoring.")
+		var default_certificate: X509Certificate = X509Certificate.new()
+		default_certificate.load("res://master_server.crt")
+		client.trusted_ssl_certificate = default_certificate
 		var connect_err = client.connect_to_url(URL)
 		if connect_err != OK:
 			push_error("Could not connect to the master server (error %d)!" % connect_err)
@@ -136,7 +139,7 @@ func connect_to_server() -> void:
 		if custom_certificate_ok:
 			client.trusted_ssl_certificate = custom_certificate
 		else:
-			push_warning("No SSL certificate was loaded for '%s', this will not end well..." % custom_server)
+			push_warning("No SSL certificate was loaded for '%s', TODO" % custom_server)
 		var connect_err = client.connect_to_url(custom_server)
 		if connect_err != OK:
 			push_error("Could not connect to the custom master server (error %d)!" % connect_err)

--- a/game/project.godot
+++ b/game/project.godot
@@ -309,10 +309,6 @@ game_shuffle_stack={
 
 translations=PoolStringArray( "res://Translations/fr.po", "res://Translations/de.po", "res://Translations/nl.po", "res://Translations/ru.po", "res://Translations/pt.po", "res://Translations/eo.po", "res://Translations/it.po", "res://Translations/es.po", "res://Translations/nb_NO.po", "res://Translations/id.po", "res://Translations/pl.po", "res://Translations/zh_Hans.po", "res://Translations/pt_BR.po" )
 
-[network]
-
-ssl/certificates="res://master_server.crt"
-
 [physics]
 
 3d/default_gravity=98.1


### PR DESCRIPTION
**Fixes/Solves**
At the moment, users can provide a custom lobby URL via command line. However, this only works if a custom SSL certificate is provided as well. This makes sense if the server uses a self-signed certificate. However, for servers with publicly trusted certificates, it should not be required to provide a .crt file manually.

The issue is caused by the fact that setting `ssl/certificates` in Project Settings results in Godot not checking for trusted certificates and, instead, using just the ones provided via `ssl/certificates`. This PR ensures that the SSL certificate will always be configured via `client.trusted_ssl_certificate` instead of Project Settings. That way, if a lobby server uses a publicly trusted certificate, users will be able to connect by providing only its URL, without the need for SSL certificate path. 

**NOTE:** Make sure this PR goes to the `master` branch! If this fix applies to
previously released versions, then the commits will be cherry-picked afterwards.
